### PR TITLE
Fix typo in context provider.

### DIFF
--- a/src/app/(tabs)/CreateRecipe.tsx
+++ b/src/app/(tabs)/CreateRecipe.tsx
@@ -27,7 +27,7 @@ async function handleImageSelection() {
 }
 
 export default function CreateRecipe() {
-  const { setRecipies, recipes } = useRecipes();
+  const { setRecipes, recipes } = useRecipes();
 
   const [recipe, setRecipe] = useState({
     id: recipes.length,
@@ -78,7 +78,7 @@ export default function CreateRecipe() {
             color="white"
             title="Save Recipe"
             onPress={() => {
-              setRecipies([...recipes, recipe]);
+              setRecipes([...recipes, recipe]);
               setRecipe({
                 id: recipes.length + 1,
                 title: "",


### PR DESCRIPTION
This pull request includes a small change to the `CreateRecipe` component in the `src/app/(tabs)/CreateRecipe.tsx` file. The change corrects the spelling of the `setRecipes` function in two places to ensure proper functionality.

* [`src/app/(tabs)/CreateRecipe.tsx`](diffhunk://#diff-acb9630f157dafb9d0eb5ee5181917f7699dec2559f53b0335c1a4873673688fL30-R30): Corrected the spelling of `setRecipes` in the `CreateRecipe` function. [[1]](diffhunk://#diff-acb9630f157dafb9d0eb5ee5181917f7699dec2559f53b0335c1a4873673688fL30-R30) [[2]](diffhunk://#diff-acb9630f157dafb9d0eb5ee5181917f7699dec2559f53b0335c1a4873673688fL81-R81)